### PR TITLE
MacVim-KaoriYa 20150211 released

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -12,5 +12,5 @@ vim74win:
   info: +kaoriya, 14/15MB ZIP
 vim74mac:
   title: OS X 10.8/9/10
-  version: '7.4.527'
+  version: '7.4.629'
   info: +macvim-kaoriya, 12MB


### PR DESCRIPTION
@kaoriya http://files.kaoriya.net/goto/vim74mac リンク更新お願いいたします!
https://github.com/splhack/macvim/releases/download/20150211/macvim-kaoriya-20150211.dmg