### PR TITLE
MacVim-KaoriYa 20150707

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -12,5 +12,5 @@ vim74win:
   info: +kaoriya, 14/15MB ZIP
 vim74mac:
   title: OS X 10.8/9/10
-  version: '7.4.712'
-  info: +macvim-kaoriya, 12MB
+  version: '7.4.769'
+  info: +macvim-kaoriya, 14MB DMG


### PR DESCRIPTION
https://github.com/splhack/macvim-kaoriya/releases/tag/20150707

DMGファイルのURLは https://github.com/splhack/macvim-kaoriya/releases/download/20150707/macvim-kaoriya-20150707.dmg です。