### PR TITLE
MacVim-KaoriYa 20151116

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -3,8 +3,8 @@ vim74win: &vim74win
   version: '7.4.884'
   info: +kaoriya, 14/15MB ZIP
 vim74mac:
-  title: OS X 10.8/9/10
-  version: '7.4.769'
+  title: OS X 10.9/10/11
+  version: '7.4.922'
   info: +macvim-kaoriya, 14MB DMG
 
 vim74w32:


### PR DESCRIPTION
https://github.com/splhack/macvim-kaoriya/releases/tag/20151116

DMGファイルのURLは https://github.com/splhack/macvim-kaoriya/releases/download/20151115/macvim-kaoriya-20151116.dmg です。