### PR TITLE
vim-jpでviのキーバインドを有効にする機能の追加の提案

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.sass-cache/
 _site
 *.un~
+Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -48,3 +48,5 @@ exclude:
 gems:
   - jemoji
   - jekyll-sitemap
+
+hotkeys: true

--- a/_includes/custom/hotkeys.html
+++ b/_includes/custom/hotkeys.html
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="https://raw.githubusercontent.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>
-<!--<script type="text/javascript" src="/assets/javascripts/jquery.hotkeys/jquery.hotkeys.js"></script>-->
+<!--<script type="text/javascript" src="https://raw.githubusercontent.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>-->
+<script type="text/javascript" src="/assets/javascripts/jquery.hotkeys.js"></script>
 <script>
 $(function(){
 	$(document).bind('keydown', 'j', function(){      

--- a/_includes/custom/hotkeys.html
+++ b/_includes/custom/hotkeys.html
@@ -13,17 +13,17 @@ $(function(){
 	})
 });
 
-$(function(){
-	$(document).bind('keydown', 'g', function(){      
-		document.location.href = '#';
-	})
-});
-
-$(function(){
-	$(document).bind('keydown', 'Shift+g', function(){      
-		document.location.href = '#footer';
-	})
-});
+//$(function(){
+//	$(document).bind('keydown', 'g', function(){      
+//		document.location.href = '#';
+//	})
+//});
+//
+//$(function(){
+//	$(document).bind('keydown', 'Shift+g', function(){      
+//		document.location.href = '#footer';
+//	})
+//});
 
 $('.move').click(function() {
     this.focus();

--- a/_includes/custom/hotkeys.html
+++ b/_includes/custom/hotkeys.html
@@ -1,5 +1,5 @@
-<!--<script type="text/javascript" src="https://raw.githubusercontent.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>-->
-<script type="text/javascript" src="/assets/javascripts/jquery.hotkeys/jquery.hotkeys.js"></script>
+<script type="text/javascript" src="https://raw.githubusercontent.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>
+<!--<script type="text/javascript" src="/assets/javascripts/jquery.hotkeys/jquery.hotkeys.js"></script>-->
 <script>
 $(function(){
 	$(document).bind('keydown', 'j', function(){      

--- a/_includes/custom/hotkeys.html
+++ b/_includes/custom/hotkeys.html
@@ -1,0 +1,35 @@
+<!--<script type="text/javascript" src="https://raw.githubusercontent.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>-->
+<script type="text/javascript" src="/assets/javascripts/jquery.hotkeys/jquery.hotkeys.js"></script>
+<script>
+$(function(){
+	$(document).bind('keydown', 'j', function(){      
+		$(".move:focus").closest('li').next().find('a.move').focus();   
+	})
+});
+
+$(function(){
+	$(document).bind('keydown', 'k', function(){      
+		$(".move:focus").closest('li').prev().find('a.move').focus();   
+	})
+});
+
+$(function(){
+	$(document).bind('keydown', 'g', function(){      
+		document.location.href = '#';
+	})
+});
+
+$(function(){
+	$(document).bind('keydown', 'Shift+g', function(){      
+		document.location.href = '#footer';
+	})
+});
+
+$('.move').click(function() {
+    this.focus();
+});
+
+$(function() {
+    $('#first').focus();
+});
+</script>

--- a/_includes/listitem-entry.html
+++ b/_includes/listitem-entry.html
@@ -1,7 +1,9 @@
 <li>
+<a href="{{ post.url }}" class="move">
 <div class="entry-head">
-	<div class="entry-label">{{ post.date | date: "%Y/%m/%d" }}&nbsp;&raquo;&nbsp;</div>
-        <div class="entry-title"><a href="{{ post.url }}">{{ post.title }}</a>&nbsp;{% assign hatena-url = post.url %}{% include hatena.html %}</div>
+	<span class="entry-label">{{ post.date | date: "%Y/%m/%d" }}&nbsp;&raquo;&nbsp;</span>
+	<span class="entry-title">{{ post.title }}&nbsp;{% assign hatena-url = post.url %}{% include hatena.html %}</span>
 </div>
+</a>
 <div class="entry-digest">{{ post.content | strip_html | truncate: 100 }}</div>
 </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,6 +71,11 @@
 </head>
 <body>
 
+<!-- hotkeys vi-normal-mode -->
+{% if site.hotkeys == true %}
+	{% include custom/hotkeys.html %}
+{% endif %}
+
 <!-- for facebook like button -->
 <div id="fb-root"></div>
 

--- a/assets/javascripts/jquery.hotkeys.js
+++ b/assets/javascripts/jquery.hotkeys.js
@@ -1,0 +1,204 @@
+/*jslint browser: true*/
+/*jslint jquery: true*/
+
+/*
+ * jQuery Hotkeys Plugin
+ * Copyright 2010, John Resig
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Based upon the plugin by Tzury Bar Yochay:
+ * https://github.com/tzuryby/jquery.hotkeys
+ *
+ * Original idea by:
+ * Binny V A, http://www.openjs.com/scripts/events/keyboard_shortcuts/
+ */
+
+/*
+ * One small change is: now keys are passed by object { keys: '...' }
+ * Might be useful, when you want to pass some other data to your handler
+ */
+
+(function(jQuery) {
+
+  jQuery.hotkeys = {
+    version: "0.2.0",
+
+    specialKeys: {
+      8: "backspace",
+      9: "tab",
+      10: "return",
+      13: "return",
+      16: "shift",
+      17: "ctrl",
+      18: "alt",
+      19: "pause",
+      20: "capslock",
+      27: "esc",
+      32: "space",
+      33: "pageup",
+      34: "pagedown",
+      35: "end",
+      36: "home",
+      37: "left",
+      38: "up",
+      39: "right",
+      40: "down",
+      45: "insert",
+      46: "del",
+      59: ";",
+      61: "=",
+      96: "0",
+      97: "1",
+      98: "2",
+      99: "3",
+      100: "4",
+      101: "5",
+      102: "6",
+      103: "7",
+      104: "8",
+      105: "9",
+      106: "*",
+      107: "+",
+      109: "-",
+      110: ".",
+      111: "/",
+      112: "f1",
+      113: "f2",
+      114: "f3",
+      115: "f4",
+      116: "f5",
+      117: "f6",
+      118: "f7",
+      119: "f8",
+      120: "f9",
+      121: "f10",
+      122: "f11",
+      123: "f12",
+      144: "numlock",
+      145: "scroll",
+      173: "-",
+      186: ";",
+      187: "=",
+      188: ",",
+      189: "-",
+      190: ".",
+      191: "/",
+      192: "`",
+      219: "[",
+      220: "\\",
+      221: "]",
+      222: "'"
+    },
+
+    shiftNums: {
+      "`": "~",
+      "1": "!",
+      "2": "@",
+      "3": "#",
+      "4": "$",
+      "5": "%",
+      "6": "^",
+      "7": "&",
+      "8": "*",
+      "9": "(",
+      "0": ")",
+      "-": "_",
+      "=": "+",
+      ";": ": ",
+      "'": "\"",
+      ",": "<",
+      ".": ">",
+      "/": "?",
+      "\\": "|"
+    },
+
+    // excludes: button, checkbox, file, hidden, image, password, radio, reset, search, submit, url
+    textAcceptingInputTypes: [
+      "text", "password", "number", "email", "url", "range", "date", "month", "week", "time", "datetime",
+      "datetime-local", "search", "color", "tel"],
+
+    // default input types not to bind to unless bound directly
+    textInputTypes: /textarea|input|select/i,
+
+    options: {
+      filterInputAcceptingElements: true,
+      filterTextInputs: true,
+      filterContentEditable: true
+    }
+  };
+
+  function keyHandler(handleObj) {
+    if (typeof handleObj.data === "string") {
+      handleObj.data = {
+        keys: handleObj.data
+      };
+    }
+
+    // Only care when a possible input has been specified
+    if (!handleObj.data || !handleObj.data.keys || typeof handleObj.data.keys !== "string") {
+      return;
+    }
+
+    var origHandler = handleObj.handler,
+      keys = handleObj.data.keys.toLowerCase().split(" ");
+
+    handleObj.handler = function(event) {
+      //      Don't fire in text-accepting inputs that we didn't directly bind to
+      if (this !== event.target &&
+        (jQuery.hotkeys.options.filterInputAcceptingElements &&
+          jQuery.hotkeys.textInputTypes.test(event.target.nodeName) ||
+          (jQuery.hotkeys.options.filterContentEditable && jQuery(event.target).attr('contenteditable')) ||
+          (jQuery.hotkeys.options.filterTextInputs &&
+            jQuery.inArray(event.target.type, jQuery.hotkeys.textAcceptingInputTypes) > -1))) {
+        return;
+      }
+
+      var special = event.type !== "keypress" && jQuery.hotkeys.specialKeys[event.which],
+        character = String.fromCharCode(event.which).toLowerCase(),
+        modif = "",
+        possible = {};
+
+      jQuery.each(["alt", "ctrl", "shift"], function(index, specialKey) {
+
+        if (event[specialKey + 'Key'] && special !== specialKey) {
+          modif += specialKey + '+';
+        }
+      });
+
+      // metaKey is triggered off ctrlKey erronously
+      if (event.metaKey && !event.ctrlKey && special !== "meta") {
+        modif += "meta+";
+      }
+
+      if (event.metaKey && special !== "meta" && modif.indexOf("alt+ctrl+shift+") > -1) {
+        modif = modif.replace("alt+ctrl+shift+", "hyper+");
+      }
+
+      if (special) {
+        possible[modif + special] = true;
+      }
+      else {
+        possible[modif + character] = true;
+        possible[modif + jQuery.hotkeys.shiftNums[character]] = true;
+
+        // "$" can be triggered as "Shift+4" or "Shift+$" or just "$"
+        if (modif === "shift+") {
+          possible[jQuery.hotkeys.shiftNums[character]] = true;
+        }
+      }
+
+      for (var i = 0, l = keys.length; i < l; i++) {
+        if (possible[keys[i]]) {
+          return origHandler.apply(this, arguments);
+        }
+      }
+    };
+  }
+
+  jQuery.each(["keydown", "keyup", "keypress"], function() {
+    jQuery.event.special[this] = {
+      add: keyHandler
+    };
+  });
+
+})(jQuery || this.jQuery || window.jQuery);

--- a/index.html
+++ b/index.html
@@ -18,37 +18,33 @@ title: Vimのユーザーと開発者を結ぶコミュニティサイト
 <a href="https://twitter.com/share" class="twitter-share-button" data-via="vim_jp" data-lang="ja">ツイート</a>
 <a href="http://b.hatena.ne.jp/entry/{{ site.base-url | escape }}" class="hatena-bookmark-button" data-hatena-bookmark-layout="standard" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only.gif" alt="このエントリーをはてなブックマークに追加" /></a>
 
-<h2>ブログ</h2>
 <ul class="entry-list2">
-{% for post in site.categories.blog limit: 5 %}
-{% include listitem-entry.html %}
-{% endfor %}
-</ul>
-<p><a href="pages.html">全記事一覧はこちら</a></p>
 
-<h2>月刊Vimマガジン</h2>
-<ul class="entry-list2">
-{% for post in site.categories.vimmagazine limit: 5 %}
-{% include listitem-entry.html %}
-{% endfor %}
-</ul>
-<p><a href="magazines.html">バックナンバーはこちら</a></p>
+	<li> <a id="first" href="pages.html" class='move'><h2>ブログ</h2></a> </li>
+	{% for post in site.categories.blog limit: 5 %}
+	{% include listitem-entry.html %}
+	{% endfor %}
+	<li> <a href="pages.html" class="move">全記事一覧はこちら</a> </li>
 
-<h2>読み物</h2>
-<ul class="entry-list2">
-	<li>&raquo;&nbsp;<a href="/docs/how_to_write_patches.html">パッチの書き方</a>&nbsp;{% assign hatena-url = '/docs/how_to_write_patches.html' %}{% include hatena.html %}</li>
-	<li>&raquo;&nbsp;<a href="/docs/patches_list.html">パッチリスト</a>&nbsp;{% assign hatena-url = '/docs/patches_list.html' %}{% include hatena.html %}</li>
-	<li>&raquo;&nbsp;<a href="/docs/build_windows_msvc.html">VisualStudio10を使ってのビルド方法</a>&nbsp;{% assign hatena-url = '/docs/build_windows_msvc.html' %}{% include hatena.html %}</li>
-	<li>&raquo;&nbsp;<a href="/docs/build_windows_mingw.html">MinGWを使ってのビルド方法</a>&nbsp;{% assign hatena-url = '/docs/build_windows_mingw.html' %}{% include hatena.html %}</li>
-	<li>&raquo;&nbsp;<a href="/docs/build_linux.html">Linuxでのビルド方法</a>&nbsp;{% assign hatena-url = '/docs/build_linux.html' %}{% include hatena.html %}</li>
-	<li>&raquo;&nbsp;<a href="/docs/install_windows.html">Windowsへのインストール方法</a>&nbsp;{% assign hatena-url = '/docs/install_windows.html' %}{% include hatena.html %}</li>
-	<li>&raquo;&nbsp;<a href="/docs/binary.html">バイナリーを配布しているサイトの紹介</a>&nbsp;{% assign hatena-url = '/docs/binary.html' %}{% include hatena.html %}</li>
-	<li>&raquo;&nbsp;<a href="/tips/list.html">Vim に関するTips</a>&nbsp;{% assign hatena-url = '/tips/list.html' %}{% include hatena.html %}</li>
+	<li> <a href="magazines.html" class="move"><h2>月刊Vimマガジン</h2></a> </li>
+	{% for post in site.categories.vimmagazine limit: 5 %}
+	{% include listitem-entry.html %}
+	{% endfor %}
+	<li> <a href="magazines.html" class="move">バックナンバーはこちら</a> </li>
+
+	<li> <a href="links.html" class="move"><h2>読み物</h2></a> </li>
+	<li>&raquo;&nbsp;<a href="/docs/how_to_write_patches.html" class="move">パッチの書き方</a>&nbsp;{% assign hatena-url = '/docs/how_to_write_patches.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/docs/patches_list.html" class="move">パッチリスト</a>&nbsp;{% assign hatena-url = '/docs/patches_list.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/docs/build_windows_msvc.html" class="move">VisualStudio10を使ってのビルド方法</a>&nbsp;{% assign hatena-url = '/docs/build_windows_msvc.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/docs/build_windows_mingw.html" class="move">MinGWを使ってのビルド方法</a>&nbsp;{% assign hatena-url = '/docs/build_windows_mingw.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/docs/build_linux.html" class="move">Linuxでのビルド方法</a>&nbsp;{% assign hatena-url = '/docs/build_linux.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/docs/install_windows.html" class="move">Windowsへのインストール方法</a>&nbsp;{% assign hatena-url = '/docs/install_windows.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/docs/binary.html" class="move">バイナリーを配布しているサイトの紹介</a>&nbsp;{% assign hatena-url = '/docs/binary.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/tips/list.html" class="move">Vim に関するTips</a>&nbsp;{% assign hatena-url = '/tips/list.html' %}{% include hatena.html %}</li>
+	<li>&raquo;&nbsp;<a href="/docs/books/vim-technique-bible/corrigenda.html" class="move">Vimテクニックバイブル 作業効率をカイゼンする150の技 正誤表</a></li>
+	<li>&raquo;&nbsp;<a href="/docs/books/vimscript-technique-bible/corrigenda.html" class="move">Vim scriptテクニックバイブル ～Vim使いの魔法の杖 正誤表</a></li>
 </ul>
-<ul class="entry-list2">
-	<li>&raquo;&nbsp;<a href="/docs/books/vim-technique-bible/corrigenda.html">Vimテクニックバイブル 作業効率をカイゼンする150の技 正誤表</a></li>
-	<li>&raquo;&nbsp;<a href="/docs/books/vimscript-technique-bible/corrigenda.html">Vim scriptテクニックバイブル ～Vim使いの魔法の杖 正誤表</a></li>
-</ul>
+
 <br />
 
 {% include twitter-widget.html %}


### PR DESCRIPTION
GoogleやHatenaでお馴染みのviのキーバインドを使ってWebサイトのコンテンツに順々にフォーカスを当てていく機能の追加を提案します。

プレビュー(jekyll serve)での動作確認はしましたが、HTML,CSS等のレイアウト等はまだ未完成であり、改善の余地があると思われます。

## テスト環境:
- OS X 10.10.5
- Firefox 42.0
- Chrome 47.0.2526.80 (64-bit)
- ruby 2.2.3
- jekyll 2.4.0

## 機能の概要

機能は、[jeresig/jquery.hotkeys](https://github.com/jeresig/jquery.hotkeys)を元に作れています。

動作のために必要最低限のコードを説明します。

> html

```html
<!--javascript-->
<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
<!--<script type="text/javascript" src="https://raw.githubusercontent.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>-->
<script type="text/javascript" src="/assets/javascripts/jquery.hotkeys/jquery.hotkeys.js"></script>
<script>
$(function(){
	$(document).bind('keydown', 'j', function(){      
		$(".move:focus").closest('li').next().find('a.move').focus();   
	})
});

$('.move').click(function() {
    this.focus();
});

$(function() {
    $('#first').focus();
});
</script>

<!--html-->
<ul>
<li> <a id="first" href="#" class='move'>Link</a> </li>
<li><a href="#" class="move">Link</a></li>
</ul>
```

これで、ブラウザ上で`j`を押すと、`id=first`を起点として、順に`class=move`を指定したリンク先へとフォーカスが移動します。

## コマンド実行例

プレビューのためのコマンドの実行例を載せておきます。

```bash
$ git clone https://github.com/syui/vim-jp.github.com

$ cd vim-jp.github.com

$ git checkout jquery-hotkeys-mini

$ jekyll serve

$ curl -sL localhost:4000
```

## 追記:

[jeresig/jquery.hotkeys](https://github.com/jeresig/jquery.hotkeys)を`clone`するのではなく、外部から読み込んで動作するように変更しました。

> branch : jquery-hotkeys-mini, _includes/custom/hotkeys.html

```html
<script type="text/javascript" src="https://raw.githubusercontent.com/jeresig/jquery.hotkeys/master/jquery.hotkeys.js"></script>
<!--<script type="text/javascript" src="/assets/javascripts/jquery.hotkeys/jquery.hotkeys.js"></script>-->
```

